### PR TITLE
Skip tasks in check_mode to improve idempotence

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,6 +38,7 @@
   get_url:
     url: "{{ jmx_exporter_url }}"
     dest: /tmp
+  when: not ansible_check_mode
 
 - name: JMX_EXPORTER | Copy binary
   copy:
@@ -47,6 +48,7 @@
     group: "{{ jmx_exporter_group }}"
     remote_src: true
     mode: 0755
+  when: not ansible_check_mode
   notify: restart jmx_exporter
 
 - name: JMX_EXPORTER | Link binary
@@ -54,6 +56,7 @@
     src: "{{ jmx_exporter_root_directory }}/{{ jmx_exporter_bin_name }}"
     dest: "{{ jmx_exporter_jar_path }}"
     state: link
+  when: not ansible_check_mode
 
 - name: JMX_EXPORTER | Copy Daemon script
   template:


### PR DESCRIPTION
### Description of the Change

Today, when we run the role with the `check_mode`, we have unexpected changes on the tasks:
- `prometheus-jmx-exporter : JMX_EXPORTER | Download binary`
- `prometheus-jmx-exporter : JMX_EXPORTER | Copy binary`
- `prometheus-jmx-exporter : JMX_EXPORTER | Link binary`

This change disables these tasks when running in `check_mode` to remove these changes in the description.

### Benefits

Because of that, the role isn't really idempotent today. We have changes even if there is nothing to change.

It permits us to test correctly the role by using `check_mode`.

### Possible Drawbacks

The possible drawback is to not test the URL of the binary with the check_mode. But there is no impact on the server targetted as it will fail if the URL isn't working anymore.

